### PR TITLE
ci: freeze Docusaurus npm dependency window

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
   apt-get update && \
   apt-get install -yqq nodejs
 
+# Resolve npm dependencies to versions available when Docusaurus 2.1 was released.
+ENV NPM_CONFIG_BEFORE=2022-09-03T00:00:00Z
+
 # Install reveal-md using npm.
 RUN npm install -g reveal-md
 


### PR DESCRIPTION
Resolve npm dependencies as of the Docusaurus 2.1 release window.

This avoids fresh installs pulling newer Webpack tooling that is incompatible with the older Docusaurus progress plugin configuration.

# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [ ] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [ ] Tested your changes against relevant architectures and platforms;
- [ ] Updated relevant documentation (if needed).

## Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
